### PR TITLE
fix(ci): add pytest-asyncio for async/streaming tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,14 @@ monitor = ["pynvml>=2.0"]
 performance = ["hive-cpp>=0.1.0"]
 dev = [
     "pytest>=8.0",
+    "pytest-asyncio>=0.24",
     "pytest-cov>=4.1",
     "ruff>=0.5",
     "mypy>=1.8",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 # Real-time observability: Prometheus, OpenTelemetry, JSONL export
 observability = [
     "prometheus-client>=0.20",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the `fe70854` feature batch (`test_async_stack`, `test_streaming`), CI fails on a clean `pip install -e .[dev]` because `pytest-asyncio` was not declared. Six tests error with "async def functions are not natively supported".

## Fix

- Add `pytest-asyncio>=0.24` to `[project.optional-dependencies].dev`
- Set `[tool.pytest.ini_options] asyncio_mode = "auto"`

## Verification

- `pytest tests/` → **177 passed**, 3 skipped
- Full pentest (`scripts/hive_pentest.py --fail-on-skip`) → **22/22 passed**
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://myworkspace-zch7314.slack.com/archives/C0B7M2J576Z/p1780534763304589?thread_ts=1780534763.304589&cid=C0B7M2J576Z)

<div><a href="https://cursor.com/agents/bc-1e561645-b1d4-53a5-af82-8a71dbf0a4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e561645-b1d4-53a5-af82-8a71dbf0a4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

