### PR TITLE
feat(security): P0 pentest modules (api, mcp, gossip) + prod profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,12 @@ jobs:
         run: |
           python -m ruff check hive/ tests/
           python -m mypy hive/ --ignore-missing-imports
-      - name: Security scan (hive only)
+      - name: Security scan (hive + HTTP surfaces)
         run: |
-          pip install bandit
-          python -m bandit -r hive/ -ll -q
-          python scripts/hive_pentest.py --module hive
+          pip install bandit pip-audit
+          python -m bandit -r hive/ scripts/hive_api_server.py scripts/hive_mcp_server.py -ll -q
+          pip-audit
+          python scripts/hive_pentest.py --module hive --module api --module mcp --module gossip --active
 
   # Full-stack pentest: hive + busybee-cpu + honey-comb
   pentest:
@@ -66,7 +67,9 @@ jobs:
         env:
           HIVE_NO_NVML: "1"
         run: |
-          python scripts/hive_pentest.py --fail-on-skip
+          pip install pip-audit
+          pip-audit
+          python scripts/hive_pentest.py --profile prod --fail-on-skip --active
 
   # x86_64 + CUDA. Requires self-hosted runner with GPU label.
   # Disabled until self-hosted runner is registered.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ runs/
 
 # Rust build artifacts
 hive-cpp/target/
+siblings/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ one. Earlier versions are best-effort.
 
 | Version | Supported           |
 |---------|---------------------|
-| 0.2.x   | :white_check_mark:  |
-| 0.1.x   | :white_check_mark:  |
-| < 0.1   | :x:                 |
+| 0.5.x   | :white_check_mark:  |
+| 0.4.x   | :white_check_mark:  |
+| < 0.4   | :x:                 |
 
 ## Reporting a Vulnerability
 
@@ -38,6 +38,10 @@ surfaces are:
   older writes. The trust score is the user-controlled input; do not
   treat high-trust nodes as authoritative in a multi-tenant setting.
 * `hive.hardware` — pynvml is read-only; no attack surface.
+* `scripts/hive_api_server.py` — REST API; set `HIVE_REQUIRE_AUTH=true` and
+  configure JWT before exposing beyond localhost.
+* `scripts/hive_mcp_server.py` — MCP tools (stdio = local trust; SSE needs auth).
+* `hive.gossip` — cross-node memory sync; set `HIVE_GOSSIP_SECRET` on receivers.
 
 Report issues in **busybee-cpu** or **honey-comb** to the same security
 contact; fixes may land in the sibling repo and be pulled into Hive releases.
@@ -48,25 +52,43 @@ Modular checks cover each installable component. Siblings are optional;
 skipped modules print install instructions.
 
 ```bash
-# Hive core only (matches default CI on PRs)
+# Hive core + HTTP/MCP/gossip (matches default CI on PRs)
 pip install -e ".[dev]"
-python scripts/hive_pentest.py --module hive
+python scripts/hive_pentest.py --module hive --module api --module mcp --module gossip
+
+# Production profile (validates auth hooks exist)
+python scripts/hive_pentest.py --profile prod --module api --module mcp --module gossip
+
+# Active HTTP checks (FastAPI TestClient)
+python scripts/hive_pentest.py --active --module api
 
 # Full stack (busyBee-cpu + honey-comb side-by-side)
 git clone https://github.com/DJLougen/busyBee-cpu ../busyBee-cpu
 git clone https://github.com/DJLougen/honey-comb ../honey-comb
 pip install -e ../busyBee-cpu ../honey-comb -e ".[dev]"
-python scripts/hive_pentest.py --fail-on-skip
+python scripts/hive_pentest.py --profile prod --fail-on-skip
 
-python -m bandit -r hive/ -ll
+python -m bandit -r hive/ scripts/hive_api_server.py scripts/hive_mcp_server.py -ll
+pip-audit
 ```
 
 | Module | Package | Focus |
 |--------|---------|--------|
 | `hive` | `hive` | JWT, tenancy, health bind, feedback poisoning, LLM URLs |
+| `api` | `scripts/hive_api_server.py` | localhost bind, JWT middleware, 413 on oversized compress |
+| `mcp` | `scripts/hive_mcp_server.py` | SSE bind, JWT middleware, tool surface, stdio trust |
+| `gossip` | `hive.gossip` | http(s) peers only, `HIVE_GOSSIP_SECRET` on receive |
 | `busybee` | `busybee_cpu` | joblib trust, `/v1/learn`, CORS, body limits, predict DoS |
 | `honeycomb` | `honeycomb` | model fallback, CORE system prompts, tee paths, large inputs |
 | `integration` | all three | `HiveStack` wired to real busybee + honeycomb |
+
+Production environment variables:
+
+| Variable | Surface | Purpose |
+|----------|---------|---------|
+| `HIVE_REQUIRE_AUTH=true` | REST API, MCP SSE | Require `Authorization: Bearer <jwt>` |
+| `HIVE_JWKS_URL` / `HIVE_JWT_PUBLIC_KEY` | JWT validation | Identity provider |
+| `HIVE_GOSSIP_SECRET` | Gossip receive | Shared secret for cross-node memory sync |
 
 For Kubernetes deployments, set `HIVE_HEALTH_BIND=0.0.0.0` only inside the
 pod network; the default is loopback (`127.0.0.1`). Always configure

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -9,3 +9,7 @@ data:
   HIVE_DEFAULT_TTL_S: "86400"
   HIVE_MAX_NODES: "10000"
   HIVE_MAX_CONTENT_BYTES: "1048576"
+  # Set via Secret in production (not committed):
+  # HIVE_REQUIRE_AUTH: "true"
+  # HIVE_JWKS_URL: "https://idp.example.com/.well-known/jwks.json"
+  # HIVE_GOSSIP_SECRET: "<shared-secret>"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -372,19 +372,23 @@ tel.export_jsonl("/var/log/hive/dump.jsonl")
 Run the modular pentest before production:
 
 ```bash
-python scripts/hive_pentest.py --module hive
+python scripts/hive_pentest.py --module hive --module api --module mcp --module gossip
+python scripts/hive_pentest.py --profile prod --module api --module mcp --module gossip
+python scripts/hive_pentest.py --active --module api
 ```
 
-With siblings installed:
+With siblings installed (full stack):
 
 ```bash
-python scripts/hive_pentest.py --active --fail-on-skip
+python scripts/hive_pentest.py --profile prod --fail-on-skip --active
 ```
 
 Key hardening checklist:
 
 - [ ] Set `HIVE_ENCRYPTION_KEY` in production
 - [ ] Configure `HIVE_JWKS_URL` + `HIVE_JWT_ISSUER`
+- [ ] Set `HIVE_REQUIRE_AUTH=true` on REST API / MCP SSE
+- [ ] Set `HIVE_GOSSIP_SECRET` on gossip receivers
 - [ ] Set `BUSYBEE_LEARN_API_KEY` (if using bee-serve)
 - [ ] Load `.joblib` models **only from trusted paths** (pickle RCE risk)
 - [ ] Run Prometheus behind a reverse proxy (binds 127.0.0.1 by default)
@@ -440,7 +444,8 @@ pytest tests/test_pentest_runner.py -v
 # Lint
 ruff check hive/ tests/
 mypy hive/ --ignore-missing-imports
-bandit -r hive/ -ll
+bandit -r hive/ scripts/hive_api_server.py scripts/hive_mcp_server.py -ll
+pip-audit
 ```
 
 ---

--- a/hive/gossip.py
+++ b/hive/gossip.py
@@ -20,11 +20,22 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import queue
 import threading
 from typing import Any
 
 _log = logging.getLogger("hive.gossip")
+
+
+def _validate_peer_url(peer: str) -> None:
+    """Only allow http(s) gossip peers (blocks file://, gopher://, etc.)."""
+    if not peer.startswith(("http://", "https://")):
+        raise ValueError(f"gossip peer URL must use http or https, got: {peer!r}")
+
+
+def _gossip_secret_configured() -> bool:
+    return bool(os.environ.get("HIVE_GOSSIP_SECRET", "").strip())
 
 
 try:
@@ -60,6 +71,8 @@ class GossipProtocol:
     ) -> None:
         self._brain = brain
         self._peers = peers
+        for peer in self._peers:
+            _validate_peer_url(peer)
         self._interval = interval
         self._batch_size = batch_size
         self._queue: queue.Queue[dict[str, Any]] = queue.Queue()
@@ -105,6 +118,7 @@ class GossipProtocol:
         headers = {"Content-Type": "application/json"}
         for peer in self._peers:
             try:
+                _validate_peer_url(peer)
                 req = urllib.request.Request(
                     f"{peer.rstrip('/')}/gossip/receive",
                     data=payload,
@@ -114,11 +128,26 @@ class GossipProtocol:
                 with urllib.request.urlopen(req, timeout=2.0) as resp:  # nosec B310
                     if resp.status == 200:
                         _log.debug("Gossiped %d events to %s", len(batch), peer)
+            except ValueError:
+                raise
             except Exception as exc:
                 _log.warning("Gossip to %s failed: %s", peer, exc)
 
-    def receive(self, events: list[dict[str, Any]]) -> int:
-        """Receive gossiped events and write them into the local brain."""
+    def receive(
+        self,
+        events: list[dict[str, Any]],
+        *,
+        auth_token: str | None = None,
+    ) -> int:
+        """Receive gossiped events and write them into the local brain.
+
+        When ``HIVE_GOSSIP_SECRET`` is set, ``auth_token`` must match or
+        :class:`PermissionError` is raised.
+        """
+        if _gossip_secret_configured():
+            expected = os.environ["HIVE_GOSSIP_SECRET"].strip()
+            if auth_token != expected:
+                raise PermissionError("Gossip authentication failed")
         applied = 0
         for ev in events:
             try:
@@ -134,4 +163,6 @@ class GossipProtocol:
         return applied
 
 
-__all__ = ["GossipProtocol"]
+validate_peer_url = _validate_peer_url
+
+__all__ = ["GossipProtocol", "validate_peer_url", "_gossip_secret_configured"]

--- a/hive/http_auth.py
+++ b/hive/http_auth.py
@@ -1,0 +1,34 @@
+"""Optional bearer JWT authentication for Hive HTTP surfaces.
+
+Set ``HIVE_REQUIRE_AUTH=true`` and configure ``HIVE_JWKS_URL`` or
+``HIVE_JWT_PUBLIC_KEY`` before exposing the REST API or MCP SSE transport.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from hive.auth import AuthError, JWTValidator
+
+
+def require_auth_enabled() -> bool:
+    """Return True when HTTP/MCP SSE endpoints must validate JWT bearer tokens."""
+    return os.environ.get("HIVE_REQUIRE_AUTH", "").lower() in ("1", "true", "yes")
+
+
+def verify_bearer_token(authorization: str | None) -> dict[str, Any]:
+    """Validate ``Authorization: Bearer <jwt>`` when auth is required.
+
+    Returns decoded claims when auth is enabled and the token is valid.
+    Returns an empty dict when auth is disabled.
+  """
+    if not require_auth_enabled():
+        return {}
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise AuthError("Missing or invalid Authorization header (expected Bearer token)")
+    token = authorization[7:].strip()
+    return JWTValidator.from_env().validate(token)
+
+
+__all__ = ["require_auth_enabled", "verify_bearer_token"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,16 +67,18 @@ dev = [
     "pytest-cov>=4.1",
     "ruff>=0.5",
     "mypy>=1.8",
+    "fastapi>=0.110",
+    "httpx>=0.27",
 ]
-
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
 # Real-time observability: Prometheus, OpenTelemetry, JSONL export
 observability = [
     "prometheus-client>=0.20",
     "opentelemetry-api>=1.40",
     "opentelemetry-sdk>=1.40",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [project.urls]
 Homepage = "https://github.com/DJLougen/hive"

--- a/scripts/hive_api_server.py
+++ b/scripts/hive_api_server.py
@@ -7,6 +7,11 @@ Usage::
 
     python scripts/hive_api_server.py --port 8080
 
+Production::
+
+    export HIVE_REQUIRE_AUTH=true
+    export HIVE_JWKS_URL=https://idp.example.com/.well-known/jwks.json
+
 Endpoints:
     POST /route        → RouteDecision
     POST /compress     → CompressedTurn
@@ -20,14 +25,17 @@ Endpoints:
 from __future__ import annotations
 
 import argparse
+import os
 from typing import Any
 
 from hive import HiveStack
+from hive.auth import AuthError
+from hive.http_auth import require_auth_enabled, verify_bearer_token
 from hive.rule_fast import RuleFastHoneyComb
 
 
 try:
-    from fastapi import FastAPI, HTTPException
+    from fastapi import FastAPI, HTTPException, Request
     from fastapi.responses import JSONResponse
     from pydantic import BaseModel, Field
     import uvicorn
@@ -36,10 +44,25 @@ try:
 except Exception:  # pragma: no cover
     _HAS_FASTAPI = False
 
+_PUBLIC_PATHS = frozenset({"/health", "/ready", "/openapi.json", "/docs", "/redoc", "/docs/oauth2-redirect"})
+
 
 if _HAS_FASTAPI:
     app = FastAPI(title="Hive Agent Memory", version="0.5.0")
-    stack = HiveStack(honey_comb=RuleFastHoneyComb())
+    _max_content = int(os.environ.get("HIVE_MAX_CONTENT_BYTES", "1048576"))
+    stack = HiveStack(honey_comb=RuleFastHoneyComb(), max_content_bytes=_max_content)
+
+    @app.middleware("http")
+    async def _auth_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
+        path = request.url.path
+        if path in _PUBLIC_PATHS or path.startswith("/docs"):
+            return await call_next(request)
+        if require_auth_enabled():
+            try:
+                verify_bearer_token(request.headers.get("Authorization"))
+            except AuthError as exc:
+                return JSONResponse({"detail": str(exc)}, status_code=401)
+        return await call_next(request)
 
     class RouteRequest(BaseModel):
         goal: str = Field(default="")
@@ -80,7 +103,10 @@ if _HAS_FASTAPI:
 
     @app.post("/compress", response_model=CompressResponse)
     async def compress(req: CompressRequest) -> CompressResponse:
-        c = stack.compress(req.role, req.content)
+        try:
+            c = stack.compress(req.role, req.content)
+        except ValueError as exc:
+            raise HTTPException(status_code=413, detail=str(exc)) from exc
         return CompressResponse(role=c.role, content=c.content, label=c.label)
 
     @app.post("/remember")
@@ -101,6 +127,7 @@ if _HAS_FASTAPI:
     async def ready() -> JSONResponse:
         try:
             from hive.health import is_healthy
+
             if is_healthy(stack):
                 return JSONResponse({"status": "ready"})
         except Exception:

--- a/scripts/hive_mcp_server.py
+++ b/scripts/hive_mcp_server.py
@@ -8,6 +8,11 @@ Usage::
 
     python scripts/hive_mcp_server.py --transport sse --port 8080
 
+Production (SSE transport only)::
+
+    export HIVE_REQUIRE_AUTH=true
+    export HIVE_JWKS_URL=https://idp.example.com/.well-known/jwks.json
+
 Tools exposed:
 - ``hive_route`` — route a decision locally
 - ``hive_compress`` — compress bloated context
@@ -20,8 +25,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 
 from hive import HiveStack
+from hive.auth import AuthError
+from hive.http_auth import require_auth_enabled, verify_bearer_token
 from hive.rule_fast import RuleFastHoneyComb
 
 
@@ -176,7 +184,19 @@ def main(argv: list[str] | None = None) -> int:
     else:
         from mcp.server.sse import SseServerTransport  # type: ignore[import]
         from starlette.applications import Starlette  # type: ignore[import]
+        from starlette.middleware import Middleware  # type: ignore[import]
+        from starlette.middleware.base import BaseHTTPMiddleware  # type: ignore[import]
+        from starlette.responses import JSONResponse  # type: ignore[import]
         from starlette.routing import Route  # type: ignore[import]
+
+        class _AuthMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+                if require_auth_enabled():
+                    try:
+                        verify_bearer_token(request.headers.get("Authorization"))
+                    except AuthError as exc:
+                        return JSONResponse({"detail": str(exc)}, status_code=401)
+                return await call_next(request)
 
         transport = SseServerTransport("/messages/")
         async def handle_sse(request):
@@ -185,9 +205,14 @@ def main(argv: list[str] | None = None) -> int:
             ) as (read, write):
                 await server.run(read, write, server.create_initialization_options())
 
-        app = Starlette(routes=[Route("/sse", handle_sse)])
+        app = Starlette(
+            routes=[Route("/sse", handle_sse)],
+            middleware=[Middleware(_AuthMiddleware)],
+        )
         import uvicorn  # type: ignore[import]
-        uvicorn.run(app, host="127.0.0.1", port=args.port)
+
+        host = os.environ.get("HIVE_MCP_BIND", "127.0.0.1")
+        uvicorn.run(app, host=host, port=args.port)
 
     return 0
 

--- a/scripts/hive_pentest.py
+++ b/scripts/hive_pentest.py
@@ -4,9 +4,15 @@
 Usage::
 
     python scripts/hive_pentest.py
-    python scripts/hive_pentest.py --module hive --module busybee
-    python scripts/hive_pentest.py --fail-on-skip   # CI: require all siblings
+    python scripts/hive_pentest.py --module hive --module api --module gossip
+    python scripts/hive_pentest.py --profile prod --fail-on-skip
+    python scripts/hive_pentest.py --active --module api
     python scripts/hive_pentest.py --json report.json
+
+Profiles::
+
+    dev  — default; documents optional auth (informational passes)
+    prod — requires production security hooks (JWT middleware, gossip secret)
 
 Install siblings for full coverage::
 

--- a/scripts/pentest/_paths.py
+++ b/scripts/pentest/_paths.py
@@ -1,0 +1,15 @@
+"""Repository path helpers for pentest modules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def repo_root() -> Path:
+    return _REPO_ROOT
+
+
+def script_path(name: str) -> Path:
+    return _REPO_ROOT / "scripts" / name

--- a/scripts/pentest/api_module.py
+++ b/scripts/pentest/api_module.py
@@ -1,0 +1,195 @@
+"""Security checks for scripts/hive_api_server.py (REST/OpenAPI)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import Any
+
+from ._paths import script_path
+from ._util import package_installed
+from . import Finding
+from .profile import is_active, is_prod
+
+
+class ApiModule:
+    name = "api"
+    description = "Hive REST API server (FastAPI)"
+
+    def is_available(self) -> bool:
+        return package_installed("hive") and script_path("hive_api_server.py").is_file()
+
+    def unavailable_reason(self) -> str:
+        if not script_path("hive_api_server.py").is_file():
+            return "scripts/hive_api_server.py not found"
+        return "hive package not importable"
+
+    def run_checks(self) -> list[Finding]:
+        findings: list[Finding] = []
+        for fn in (
+            _check_default_bind_localhost,
+            _check_auth_middleware_wired,
+            _check_prod_auth_documented,
+            _check_compress_error_mapping,
+            _check_active_health_and_auth,
+        ):
+            f = fn()
+            f.module = self.name
+            findings.append(f)
+        return findings
+
+
+def _api_source() -> str:
+    return script_path("hive_api_server.py").read_text(encoding="utf-8")
+
+
+def _check_default_bind_localhost() -> Finding:
+    src = _api_source()
+    if 'default="127.0.0.1"' in src or "default='127.0.0.1'" in src:
+        return Finding(
+            "medium",
+            "API server defaults to localhost",
+            "CLI --host defaults to 127.0.0.1; use reverse proxy + TLS in production",
+            True,
+        )
+    return Finding(
+        "medium",
+        "API server bind default",
+        "Review --host default in scripts/hive_api_server.py",
+        False,
+    )
+
+
+def _check_auth_middleware_wired() -> Finding:
+    src = _api_source()
+    if "verify_bearer_token" in src and "require_auth_enabled" in src:
+        return Finding(
+            "high",
+            "API server JWT middleware present",
+            "HIVE_REQUIRE_AUTH enables bearer JWT validation via hive.http_auth",
+            True,
+        )
+    return Finding(
+        "critical",
+        "API server missing auth middleware",
+        "Wire hive.http_auth before exposing REST API",
+        False,
+    )
+
+
+def _check_prod_auth_documented() -> Finding:
+    src = _api_source()
+    has_doc = "HIVE_REQUIRE_AUTH" in src
+    if is_prod():
+        if has_doc and "verify_bearer_token" in src:
+            return Finding(
+                "high",
+                "Production API auth hook available",
+                "Set HIVE_REQUIRE_AUTH=true and configure HIVE_JWKS_URL in production",
+                True,
+            )
+        return Finding(
+            "critical",
+            "Production API lacks auth controls",
+            "Implement and document HIVE_REQUIRE_AUTH for production deployments",
+            False,
+        )
+    return Finding(
+        "info",
+        "API auth optional in dev profile",
+        "HIVE_REQUIRE_AUTH defaults off — enable in production",
+        has_doc,
+    )
+
+
+def _check_compress_error_mapping() -> Finding:
+    src = _api_source()
+    if "HTTPException" in src and "status_code=413" in src:
+        return Finding(
+            "medium",
+            "API maps oversized compress to HTTP 413",
+            "compress() ValueError surfaced as 413 Payload Too Large",
+            True,
+        )
+    return Finding(
+        "medium",
+        "API compress error mapping",
+        "Oversized compress may return 500 instead of 413",
+        False,
+    )
+
+
+def _check_active_health_and_auth() -> Finding:
+    if not is_active():
+        return Finding(
+            "info",
+            "API active tests skipped",
+            "Re-run with --active to exercise FastAPI TestClient",
+            True,
+        )
+    try:
+        from fastapi.testclient import TestClient
+    except ImportError:
+        return Finding(
+            "info",
+            "API active tests skipped",
+            "Install fastapi to run active HTTP checks",
+            True,
+        )
+
+    mod = _load_api_module()
+    if mod is None or not getattr(mod, "_HAS_FASTAPI", False):
+        return Finding(
+            "info",
+            "API active tests skipped",
+            "FastAPI not available in hive_api_server",
+            True,
+        )
+
+    client = TestClient(mod.app)
+    if client.get("/health").status_code != 200:
+        return Finding("high", "API /health failed", "Expected 200 from /health", False)
+
+    prev_auth = os.environ.pop("HIVE_REQUIRE_AUTH", None)
+    try:
+        r = client.post("/compress", json={"role": "user", "content": "x" * 2_000_000})
+        if r.status_code not in (413, 422, 400):
+            return Finding(
+                "medium",
+                "API active compress limit",
+                f"Expected 4xx for 2MB body, got {r.status_code}",
+                False,
+            )
+    finally:
+        if prev_auth is not None:
+            os.environ["HIVE_REQUIRE_AUTH"] = prev_auth
+
+    os.environ["HIVE_REQUIRE_AUTH"] = "true"
+    try:
+        r = client.post("/remember", json={"key": "k", "value": 1})
+        if r.status_code != 401:
+            return Finding(
+                "critical",
+                "API active auth enforcement",
+                f"Expected 401 without bearer token, got {r.status_code}",
+                False,
+            )
+    finally:
+        os.environ.pop("HIVE_REQUIRE_AUTH", None)
+
+    return Finding(
+        "high",
+        "API active HTTP checks passed",
+        "/health OK; oversized compress rejected; HIVE_REQUIRE_AUTH returns 401",
+        True,
+    )
+
+
+def _load_api_module() -> Any | None:
+    path = script_path("hive_api_server.py")
+    spec = importlib.util.spec_from_file_location("hive_api_server", path)
+    if spec is None or spec.loader is None:
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod

--- a/scripts/pentest/gossip_module.py
+++ b/scripts/pentest/gossip_module.py
@@ -1,0 +1,167 @@
+"""Security checks for hive.gossip (distributed memory sync)."""
+
+from __future__ import annotations
+
+import inspect
+import os
+
+from hive.gossip import GossipProtocol, validate_peer_url
+from hive.rust_brain import RustBrain
+
+from ._util import package_installed
+from . import Finding
+from .profile import is_prod
+
+
+class GossipModule:
+    name = "gossip"
+    description = "Hive gossip protocol (cross-node memory)"
+
+    def is_available(self) -> bool:
+        return package_installed("hive")
+
+    def unavailable_reason(self) -> str:
+        return "hive package not importable"
+
+    def run_checks(self) -> list[Finding]:
+        findings: list[Finding] = []
+        for fn in (
+            _check_peer_url_scheme_validation,
+            _check_receive_secret_gate,
+            _check_prod_gossip_secret_required,
+            _check_receive_rejects_bad_secret,
+            _check_gossip_batch_rejects_file_scheme,
+        ):
+            f = fn()
+            f.module = self.name
+            findings.append(f)
+        return findings
+
+
+def _check_peer_url_scheme_validation() -> Finding:
+    try:
+        validate_peer_url("http://hive-2:8080")
+        validate_peer_url("https://hive-3:8080")
+    except ValueError:
+        return Finding(
+            "high",
+            "Gossip peer URL validation",
+            "http(s) peers should be accepted",
+            False,
+        )
+    for bad in ("file:///etc/passwd", "gopher://evil", "javascript:alert(1)"):
+        try:
+            validate_peer_url(bad)
+            return Finding(
+                "high",
+                "Gossip peer URL validation bypass",
+                f"Accepted disallowed scheme: {bad!r}",
+                False,
+            )
+        except ValueError:
+            continue
+    return Finding(
+        "high",
+        "Gossip peer URLs restricted to http(s)",
+        "validate_peer_url rejects non-http(s) schemes",
+        True,
+    )
+
+
+def _check_receive_secret_gate() -> Finding:
+    src = inspect.getsource(GossipProtocol.receive)
+    if "HIVE_GOSSIP_SECRET" in src and "PermissionError" in src:
+        return Finding(
+            "high",
+            "Gossip receive supports shared secret",
+            "Set HIVE_GOSSIP_SECRET and pass auth_token to receive() at HTTP boundary",
+            True,
+        )
+    return Finding(
+        "critical",
+        "Gossip receive lacks authentication hook",
+        "Add HIVE_GOSSIP_SECRET verification to receive()",
+        False,
+    )
+
+
+def _check_prod_gossip_secret_required() -> Finding:
+    if is_prod():
+        src = inspect.getsource(GossipProtocol.receive)
+        if "HIVE_GOSSIP_SECRET" in src:
+            return Finding(
+                "high",
+                "Production gossip secret hook available",
+                "Set HIVE_GOSSIP_SECRET in production before exposing /gossip/receive",
+                True,
+            )
+        return Finding(
+            "critical",
+            "Production gossip lacks authentication",
+            "receive() must verify HIVE_GOSSIP_SECRET in production",
+            False,
+        )
+    return Finding(
+        "info",
+        "Gossip secret optional in dev profile",
+        "HIVE_GOSSIP_SECRET not required for local dev",
+        True,
+    )
+
+
+def _check_receive_rejects_bad_secret() -> Finding:
+    brain = RustBrain()
+    gossip = GossipProtocol(brain, peers=[])
+    prev = os.environ.get("HIVE_GOSSIP_SECRET")
+    os.environ["HIVE_GOSSIP_SECRET"] = "test-secret"
+    try:
+        try:
+            gossip.receive([{"key": "k", "value": "v"}], auth_token="wrong")
+            return Finding(
+                "critical",
+                "Gossip accepts invalid secret",
+                "receive() should raise PermissionError for bad auth_token",
+                False,
+            )
+        except PermissionError:
+            n = gossip.receive(
+                [{"key": "k2", "value": "v2"}],
+                auth_token="test-secret",
+            )
+            if n != 1 or brain.recall("k2") != "v2":
+                return Finding(
+                    "high",
+                    "Gossip valid secret path",
+                    "receive() with correct secret should apply events",
+                    False,
+                )
+    finally:
+        if prev is None:
+            os.environ.pop("HIVE_GOSSIP_SECRET", None)
+        else:
+            os.environ["HIVE_GOSSIP_SECRET"] = prev
+    return Finding(
+        "high",
+        "Gossip receive enforces shared secret",
+        "Invalid auth_token rejected; valid token applies events",
+        True,
+    )
+
+
+def _check_gossip_batch_rejects_file_scheme() -> Finding:
+    brain = RustBrain()
+    try:
+        GossipProtocol(brain, peers=["file:///tmp"])
+        return Finding(
+            "medium",
+            "Gossip peer validation at init",
+            "file:// peer should be rejected when constructing GossipProtocol",
+            False,
+        )
+    except ValueError:
+        return Finding(
+            "medium",
+            "Gossip validates peer URLs at init",
+            "GossipProtocol rejects file:// peers before background gossip starts",
+            True,
+        )

--- a/scripts/pentest/honeycomb_module.py
+++ b/scripts/pentest/honeycomb_module.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import tempfile
-import time
 from pathlib import Path
 
 from . import Finding

--- a/scripts/pentest/mcp_module.py
+++ b/scripts/pentest/mcp_module.py
@@ -1,0 +1,134 @@
+"""Security checks for scripts/hive_mcp_server.py (MCP)."""
+
+from __future__ import annotations
+
+from ._paths import script_path
+from ._util import package_installed
+from . import Finding
+from .profile import is_prod
+
+
+class McpModule:
+    name = "mcp"
+    description = "Hive MCP server (stdio + SSE)"
+
+    def is_available(self) -> bool:
+        return package_installed("hive") and script_path("hive_mcp_server.py").is_file()
+
+    def unavailable_reason(self) -> str:
+        if not script_path("hive_mcp_server.py").is_file():
+            return "scripts/hive_mcp_server.py not found"
+        return "hive package not importable"
+
+    def run_checks(self) -> list[Finding]:
+        findings: list[Finding] = []
+        for fn in (
+            _check_sse_bind_localhost,
+            _check_sse_auth_middleware,
+            _check_prod_mcp_auth_documented,
+            _check_mcp_tools_documented,
+            _check_stdio_trust_boundary,
+        ):
+            f = fn()
+            f.module = self.name
+            findings.append(f)
+        return findings
+
+
+def _mcp_source() -> str:
+    return script_path("hive_mcp_server.py").read_text(encoding="utf-8")
+
+
+def _check_sse_bind_localhost() -> Finding:
+    src = _mcp_source()
+    if 'HIVE_MCP_BIND' in src and "127.0.0.1" in src:
+        return Finding(
+            "medium",
+            "MCP SSE defaults to localhost",
+            "HIVE_MCP_BIND defaults to 127.0.0.1 for SSE transport",
+            True,
+        )
+    if 'host="127.0.0.1"' in src or "host='127.0.0.1'" in src:
+        return Finding(
+            "medium",
+            "MCP SSE binds localhost",
+            "uvicorn host is 127.0.0.1 for SSE",
+            True,
+        )
+    return Finding(
+        "medium",
+        "MCP SSE bind",
+        "Review SSE bind address in hive_mcp_server.py",
+        False,
+    )
+
+
+def _check_sse_auth_middleware() -> Finding:
+    src = _mcp_source()
+    if "verify_bearer_token" in src and "_AuthMiddleware" in src:
+        return Finding(
+            "high",
+            "MCP SSE JWT middleware present",
+            "HIVE_REQUIRE_AUTH gates SSE when enabled",
+            True,
+        )
+    return Finding(
+        "critical",
+        "MCP SSE missing auth middleware",
+        "Add bearer JWT middleware for SSE transport",
+        False,
+    )
+
+
+def _check_prod_mcp_auth_documented() -> Finding:
+    src = _mcp_source()
+    if is_prod():
+        if "HIVE_REQUIRE_AUTH" in src and "verify_bearer_token" in src:
+            return Finding(
+                "high",
+                "Production MCP auth hook available",
+                "Set HIVE_REQUIRE_AUTH=true for SSE deployments",
+                True,
+            )
+        return Finding(
+            "critical",
+            "Production MCP lacks auth controls",
+            "Document and enforce HIVE_REQUIRE_AUTH for MCP SSE",
+            False,
+        )
+    return Finding(
+        "info",
+        "MCP auth optional in dev profile",
+        "stdio transport is local-trust; enable HIVE_REQUIRE_AUTH for SSE in prod",
+        "HIVE_REQUIRE_AUTH" in src,
+    )
+
+
+def _check_mcp_tools_documented() -> Finding:
+    src = _mcp_source()
+    dangerous = ("hive_remember", "hive_recall", "hive_search")
+    if all(t in src for t in dangerous):
+        return Finding(
+            "medium",
+            "MCP memory tools exposed",
+            "hive_remember/recall/search are powerful — scope clients and enable auth in prod",
+            True,
+        )
+    return Finding(
+        "medium",
+        "MCP tool surface",
+        "Could not verify MCP tool registrations",
+        False,
+    )
+
+
+def _check_stdio_trust_boundary() -> Finding:
+    src = _mcp_source()
+    if "stdio" in src:
+        return Finding(
+            "info",
+            "MCP stdio trust boundary",
+            "stdio transport assumes a trusted local client (Cursor/Claude Desktop)",
+            True,
+        )
+    return Finding("info", "MCP stdio", "stdio transport not found", False)

--- a/scripts/pentest/profile.py
+++ b/scripts/pentest/profile.py
@@ -1,0 +1,31 @@
+"""Pentest profile helpers (dev vs production expectations)."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+Profile = Literal["dev", "prod"]
+
+_PROFILE_ENV = "HIVE_PENTEST_PROFILE"
+
+
+def get_profile() -> Profile:
+    raw = os.environ.get(_PROFILE_ENV, "dev").lower()
+    return "prod" if raw == "prod" else "dev"
+
+
+def is_prod() -> bool:
+    return get_profile() == "prod"
+
+
+def is_active() -> bool:
+    return os.environ.get("HIVE_PENTEST_ACTIVE", "").lower() in ("1", "true", "yes")
+
+
+def set_profile(profile: Profile) -> None:
+    os.environ[_PROFILE_ENV] = profile
+
+
+def set_active(active: bool) -> None:
+    os.environ["HIVE_PENTEST_ACTIVE"] = "1" if active else "0"

--- a/scripts/pentest/runner.py
+++ b/scripts/pentest/runner.py
@@ -3,18 +3,35 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
-from dataclasses import asdict
 from typing import Any
 
 from . import Finding, finding_to_dict
+from .api_module import ApiModule
 from .busybee_module import BusybeeModule
+from .gossip_module import GossipModule
 from .hive_module import HiveModule
 from .honeycomb_module import HoneycombModule
 from .integration_module import IntegrationModule
+from .mcp_module import McpModule
+from .profile import set_active, set_profile
+
+MODULE_NAMES = (
+    "hive",
+    "api",
+    "mcp",
+    "gossip",
+    "busybee",
+    "honeycomb",
+    "integration",
+)
 
 ALL_MODULES = (
     HiveModule(),
+    ApiModule(),
+    McpModule(),
+    GossipModule(),
     BusybeeModule(),
     HoneycombModule(),
     IntegrationModule(),
@@ -48,8 +65,19 @@ def main(argv: list[str] | None = None) -> int:
         "--module",
         action="append",
         dest="modules",
-        choices=["hive", "busybee", "honeycomb", "integration"],
+        choices=list(MODULE_NAMES),
         help="Run only these modules (default: all)",
+    )
+    p.add_argument(
+        "--profile",
+        choices=["dev", "prod"],
+        default="dev",
+        help="dev: informational auth gaps; prod: require production security hooks",
+    )
+    p.add_argument(
+        "--active",
+        action="store_true",
+        help="Run active HTTP checks (FastAPI TestClient) where supported",
     )
     p.add_argument("--json", metavar="PATH", help="Write JSON report")
     p.add_argument(
@@ -59,10 +87,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = p.parse_args(argv)
 
+    set_profile(args.profile)  # type: ignore[arg-type]
+    set_active(args.active)
+
     only = set(args.modules) if args.modules else None
     findings, skipped = run_modules(ALL_MODULES, only=only)
     failed = [f for f in findings if not f.passed]
 
+    print(f"Profile: {args.profile}" + (" | active HTTP checks enabled" if args.active else ""))
     for name, reason in skipped:
         print(f"[SKIP] module={name}")
         print(f"       {reason}")
@@ -89,12 +121,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         payload = {
             "passed": len(failed) == 0 and (not args.fail_on_skip or not skipped),
+            "profile": args.profile,
+            "active": args.active,
             "findings": [finding_to_dict(f) for f in findings],
             "skipped": [{"module": n, "reason": r} for n, r in skipped],
         }
         with open(args.json, "w", encoding="utf-8") as fh:
-            import json
-
             json.dump(payload, fh, indent=2)
         print(f"Wrote {args.json}")
 

--- a/tests/test_gossip_security.py
+++ b/tests/test_gossip_security.py
@@ -1,0 +1,33 @@
+"""Security regression tests for hive.gossip."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hive.gossip import GossipProtocol, validate_peer_url
+from hive.rust_brain import RustBrain
+
+
+def test_validate_peer_url_rejects_non_http():
+    with pytest.raises(ValueError, match="http or https"):
+        validate_peer_url("file:///etc/passwd")
+
+
+def test_gossip_receive_requires_secret_when_configured():
+    brain = RustBrain()
+    gossip = GossipProtocol(brain, peers=[])
+    os.environ["HIVE_GOSSIP_SECRET"] = "s3cret"
+    try:
+        with pytest.raises(PermissionError):
+            gossip.receive([{"key": "k", "value": 1}], auth_token="bad")
+        assert gossip.receive([{"key": "k", "value": 1}], auth_token="s3cret") == 1
+    finally:
+        os.environ.pop("HIVE_GOSSIP_SECRET", None)
+
+
+def test_gossip_rejects_file_peer_at_init():
+    brain = RustBrain()
+    with pytest.raises(ValueError, match="http or https"):
+        GossipProtocol(brain, peers=["file:///tmp"])

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -1,0 +1,25 @@
+"""Tests for hive.http_auth."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hive.auth import AuthError
+from hive.http_auth import require_auth_enabled, verify_bearer_token
+
+
+def test_auth_disabled_by_default():
+    os.environ.pop("HIVE_REQUIRE_AUTH", None)
+    assert not require_auth_enabled()
+    assert verify_bearer_token(None) == {}
+
+
+def test_auth_required_rejects_missing_header():
+    os.environ["HIVE_REQUIRE_AUTH"] = "true"
+    try:
+        with pytest.raises(AuthError, match="Missing"):
+            verify_bearer_token(None)
+    finally:
+        os.environ.pop("HIVE_REQUIRE_AUTH", None)

--- a/tests/test_pentest_extended.py
+++ b/tests/test_pentest_extended.py
@@ -1,0 +1,45 @@
+"""Tests for api/mcp/gossip pentest modules."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from pentest.api_module import ApiModule  # noqa: E402
+from pentest.gossip_module import GossipModule  # noqa: E402
+from pentest.mcp_module import McpModule  # noqa: E402
+from pentest.profile import set_profile  # noqa: E402
+from pentest.runner import run_modules  # noqa: E402
+
+
+def test_api_module_passes_dev():
+    set_profile("dev")
+    findings, skipped = run_modules((ApiModule(),))
+    assert not skipped
+    assert findings
+    assert all(f.passed for f in findings), [f.title for f in findings if not f.passed]
+
+
+def test_mcp_module_passes_dev():
+    set_profile("dev")
+    findings, skipped = run_modules((McpModule(),))
+    assert not skipped
+    assert all(f.passed for f in findings)
+
+
+def test_gossip_module_passes_dev():
+    set_profile("dev")
+    findings, skipped = run_modules((GossipModule(),))
+    assert not skipped
+    assert all(f.passed for f in findings)
+
+
+def test_gossip_module_passes_prod():
+    set_profile("prod")
+    findings, skipped = run_modules((GossipModule(),))
+    assert not skipped
+    assert all(f.passed for f in findings)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands the modular pentest suite and adds minimal hardening so production deployments can enforce auth on new HTTP/MCP/gossip surfaces.

## Pentest (37 checks)

| Module | Checks |
|--------|--------|
| **api** | localhost default, JWT middleware, prod hooks, HTTP 413 on oversized compress, active TestClient |
| **mcp** | SSE localhost bind, JWT middleware on SSE, tool surface, stdio trust boundary |
| **gossip** | http(s) peers only, `HIVE_GOSSIP_SECRET` on receive, prod hooks |

### CLI

```bash
python scripts/hive_pentest.py --profile prod --fail-on-skip --active
```

- `--profile dev` (default): informational passes for optional auth
- `--profile prod`: requires production security hooks to exist
- `--active`: FastAPI TestClient checks on REST API (`/health`, compress limits, `HIVE_REQUIRE_AUTH`)

## Hardening

- **`hive/http_auth.py`**: `HIVE_REQUIRE_AUTH` + bearer JWT via existing `JWTValidator`
- **`scripts/hive_api_server.py`**: auth middleware, 413 on oversized compress
- **`scripts/hive_mcp_server.py`**: auth middleware on SSE; `HIVE_MCP_BIND` default `127.0.0.1`
- **`hive/gossip.py`**: validate peers at init; optional `HIVE_GOSSIP_SECRET` on `receive()`

## CI

- **PR job**: bandit on `hive/` + API/MCP scripts, `pip-audit`, pentest `hive+api+mcp+gossip --active`
- **Full-stack job**: `--profile prod --fail-on-skip --active` + `pip-audit`

## Tests

- `tests/test_http_auth.py`, `tests/test_gossip_security.py`, `tests/test_pentest_extended.py`
- **188 passed** locally

## Production env vars

| Variable | Purpose |
|----------|---------|
| `HIVE_REQUIRE_AUTH=true` | REST API + MCP SSE require Bearer JWT |
| `HIVE_JWKS_URL` / `HIVE_JWT_PUBLIC_KEY` | JWT validation |
| `HIVE_GOSSIP_SECRET` | Shared secret for gossip `receive()` |
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://myworkspace-zch7314.slack.com/archives/C0B7M2J576Z/p1780534763304589?thread_ts=1780534763.304589&cid=C0B7M2J576Z)

<div><a href="https://cursor.com/agents/bc-1e561645-b1d4-53a5-af82-8a71dbf0a4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e561645-b1d4-53a5-af82-8a71dbf0a4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

