### PR TITLE
Release v0.6.1: PyPI publishing, dependency refresh, snapshot integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,28 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
   create-release:
     name: Create GitHub Release
-    needs: [build-wheels, build-sdist]
+    needs: [build-wheels, build-sdist, publish-pypi]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Hive are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.1] - 2026-06-29
 
 ### Security
 - `rust_brain` snapshot integrity: `RustBrain.snapshot_to_file` now embeds the
@@ -15,10 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ValueError("snapshot checksum mismatch ...")` and leaves the existing store
   untouched. Backward compatible: pre-checksum snapshots skip verification.
 
+### Added
+- PyPI publishing in the release workflow (trusted publishing via GitHub OIDC).
+- `[full]` optional extra: `busybee-cpu` + `honey-comb` pulled from PyPI.
+- `docs/PYPI.md` with one-time publisher setup instructions.
+
+### Changed
+- Dependency pins refreshed across core, dev, observability, and GPU extras.
+- `hive_api_server` reads version from `hive.__version__` instead of a hardcoded string.
+
 ### Tests
 - Replaced the catch-all corruption test with deterministic checks: content
   tamper → checksum `ValueError`, restore atomicity (existing data survives a
   failed restore), and truncated-file framing failure.
+
+## [Unreleased]
 
 ## [0.6.0] - 2026-06-11
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,18 @@ benchmark suite, the documentation, and the CI matrix.
 
 ## Development setup
 
+**End users** install from PyPI:
+
+```bash
+pip install hive-agent-memory
+pip install "hive-agent-memory[full]"   # when busybee-cpu + honey-comb are on PyPI
+```
+
+**Contributors** clone the meta-package and its siblings side-by-side:
+
 ```bash
 # 1. Clone all three repos side-by-side. The hive meta-package depends
-#    on busyBee-cpu and honey-comb as sibling packages.
+#    on busyBee-cpu and honey-comb as sibling packages for full-stack dev.
 git clone https://github.com/DJLougen/hive
 git clone https://github.com/DJLougen/busyBee-cpu
 git clone https://github.com/DJLougen/honey-comb
@@ -19,7 +28,7 @@ cd hive
 python -m venv .venv && . .venv/bin/activate
 pip install -e ../busyBee-cpu ../honey-comb -e ".[dev,monitor]"
 
-# 3. Run the test suite. We expect 37 tests to pass in well under 10 s.
+# 3. Run the test suite.
 pytest -q
 
 # 4. Run the macro benchmark (echo backend — no model server required).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Orchestration layer for AI agents** — CPU-side action routing, context compression, and causal graph memory that keep mechanical work and context bloat off the LLM.
 
-[![Version](https://img.shields.io/badge/version-0.6.0-blue)](https://github.com/DJLougen/hive)
+[![Version](https://img.shields.io/badge/version-0.6.1-blue)](https://github.com/DJLougen/hive)
 [![Python](https://img.shields.io/badge/python-3.10+-green)](https://python.org)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen)](https://github.com/DJLougen/hive/actions)
 [![License](https://img.shields.io/badge/license-MIT-yellow)](https://opensource.org/licenses/MIT)
@@ -11,7 +11,7 @@
 
 Hive sits between an agent loop and its LLM. It answers the mechanical decisions on the CPU, compresses the context the LLM actually sees, and keeps a timestamped causal-memory graph so the agent stops re-deriving what it already learned. On a 20-instance SWE-bench-lite A/B (GPT-2 backend) this cut LLM calls by 91.7% and resolved 85% of instances versus 0% for the un-augmented agent — numbers below.
 
-> **Status:** v0.6.0 (Beta). The core stack plus the enterprise, reliability and observability modules are implemented and tested (34 test files). Routing-accuracy numbers are *in-distribution* — see the OOD caveat under [Components](#components).
+> **Status:** v0.6.1 (Beta). The core stack plus the enterprise, reliability and observability modules are implemented and tested (34 test files). Routing-accuracy numbers are *in-distribution* — see the OOD caveat under [Components](#components).
 
 ---
 
@@ -145,6 +145,12 @@ External siblings (developed in their own repos, all optional):
 pip install hive-agent-memory
 ```
 
+Full stack (trained CPU router + ML compressor, when sibling packages are on PyPI):
+
+```bash
+pip install "hive-agent-memory[full]"
+```
+
 Optional extras:
 
 ```bash
@@ -154,7 +160,7 @@ pip install "hive-agent-memory[performance]"     # native Rust backend (hive-cpp
 pip install "hive-agent-memory[gpu]"             # torch + transformers (examples / integration)
 ```
 
-From source:
+From source (development — clones sibling repos for full-stack work):
 
 ```bash
 git clone https://github.com/DJLougen/hive.git
@@ -162,6 +168,8 @@ cd hive
 pip install -e ".[dev]"
 pytest
 ```
+
+For publishing and one-time PyPI setup, see [`docs/PYPI.md`](docs/PYPI.md).
 
 ---
 
@@ -364,7 +372,7 @@ Wheels for Linux / macOS / Windows (x86_64 + aarch64) are built by the `rust-whe
 Hive ships container and orchestration assets:
 
 - **HTTP server** — [`scripts/hive_api_server.py`](scripts/hive_api_server.py) (FastAPI). Endpoints: `POST /route`, `POST /compress`, `POST /remember`, `GET /recall`, plus `GET /health` and `GET /ready` probes. `AsyncHiveStack` backs high-throughput deployments.
-- **Helm chart** — [`deploy/helm/`](deploy/helm/) (chart `0.6.0`).
+- **Helm chart** — [`deploy/helm/`](deploy/helm/) (chart `0.6.1`).
 - **Raw K8s manifests** — [`deploy/k8s/`](deploy/k8s/) (Deployment, Service, ConfigMap).
 - **ARM64 image** — [`docker/Dockerfile.aarch64`](docker/Dockerfile.aarch64) for Jetson / Grace.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,25 @@
 
 This document contains release notes for tagged versions of Hive.
 
+## v0.6.1 (2026-06-29)
+
+### Highlights
+Security fix for rust_brain snapshot restore, PyPI distribution, and refreshed dependency pins.
+
+### Security
+- `restore_from_file` now verifies SHA-256 checksums embedded in snapshots; tampered files raise `ValueError` and leave existing state untouched.
+
+### Added
+- PyPI publishing via the release workflow (tag `v*` → build wheels/sdist → upload).
+- `[full]` extra installs `busybee-cpu` and `honey-comb` from PyPI.
+
+### Changed
+- Core and optional dependency minimum versions bumped (see `pyproject.toml`).
+- FastAPI server version tracks `hive.__version__`.
+
+### Migration
+No code changes required. Update version pins to `hive-agent-memory>=0.6.1,<0.7.0`.
+
 ## v0.6.0 (2026-06-11)
 
 ### Highlights

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: hive
-version: 0.6.0
+version: 0.6.1
 description: Hive agent memory and context compression stack
-appVersion: "0.6.0"
+appVersion: "0.6.1"

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,7 +1,19 @@
 # Hive Migration Guide
 
-**Version**: 0.5.0 → 0.6.0  
+**Version**: 0.6.0 → 0.6.1  
 **Policy**: Semantic versioning with deprecation warnings.
+
+---
+
+## 0.6.0 → 0.6.1
+
+No breaking API changes. Snapshot restore now verifies SHA-256 checksums when present.
+
+```bash
+pip install --upgrade "hive-agent-memory>=0.6.1,<0.7.0"
+```
+
+Pre-checksum snapshots (from 0.6.0 and earlier) restore without verification, as before.
 
 ---
 
@@ -67,8 +79,8 @@ None. All changes were backward-compatible additions.
 |-------------|--------|-------|----------|--------------|--------|
 | 0.3.x | 3.10+ | N/A | N/A | N/A | maintained |
 | 0.4.x | 3.10+ | N/A | N/A | N/A | maintained |
-| 0.5.x | 3.10+ | ≥2.8 | ≥2.0 | ≥41.0 | current |
-| 0.6.x | 3.10+ | ≥2.8 | ≥2.0 | ≥41.0 | planned |
+| 0.5.x | 3.10+ | ≥2.8 | ≥2.0 | ≥41.0 | maintained |
+| 0.6.x | 3.10+ | ≥2.10 | ≥2.10 | ≥43.0 | current |
 
 ---
 
@@ -76,7 +88,7 @@ None. All changes were backward-compatible additions.
 
 ```bash
 # 1. Pin version
-pip install "hive-agent-memory>=0.5.0,<0.6.0"
+pip install "hive-agent-memory>=0.6.1,<0.7.0"
 
 # 2. Run tests
 pytest tests/ -v

--- a/docs/PYPI.md
+++ b/docs/PYPI.md
@@ -1,0 +1,68 @@
+# PyPI Publishing
+
+Hive publishes **`hive-agent-memory`** to [PyPI](https://pypi.org/project/hive-agent-memory/) on every tagged release (`v*`).
+
+## Install
+
+```bash
+pip install hive-agent-memory
+pip install "hive-agent-memory[full]"          # + busybee-cpu + honey-comb
+pip install "hive-agent-memory[observability]"
+```
+
+## One-time publisher setup
+
+### 1. Create the PyPI project
+
+1. Register at [pypi.org](https://pypi.org/account/register/) (if needed).
+2. Create a project named **`hive-agent-memory`** (must match `pyproject.toml`).
+
+### 2. Enable trusted publishing (recommended)
+
+In the PyPI project → **Publishing** → **Add a new pending publisher**:
+
+| Field | Value |
+|---|---|
+| PyPI project name | `hive-agent-memory` |
+| Owner | `DJLougen` |
+| Repository name | `hive` |
+| Workflow name | `Release` |
+| Environment name | `pypi` |
+
+In GitHub → **Settings → Environments** → create environment **`pypi`** (no secrets required when using OIDC).
+
+### 3. Sibling packages
+
+The `[full]` extra depends on:
+
+| Package | PyPI name | Repo |
+|---|---|---|
+| CPU action router | `busybee-cpu` | [busyBee-cpu](https://github.com/DJLougen/busyBee-cpu) |
+| ML compressor | `honey-comb` | [honey-comb](https://github.com/DJLougen/honey-comb) |
+| Native backend | `hive-cpp` | bundled in this repo at `hive-cpp/` |
+
+Publish siblings from their own repos with the same trusted-publishing pattern before `pip install "hive-agent-memory[full]"` works end-to-end.
+
+### 4. Cut a release
+
+```bash
+# On main, after CHANGELOG and version bumps land:
+git tag v0.6.1
+git push origin v0.6.1
+```
+
+The [Release workflow](.github/workflows/release.yml) will:
+
+1. Build wheels (Linux / macOS / Windows) and an sdist
+2. Upload artifacts to the GitHub Release
+3. Publish to PyPI via OIDC
+
+### Manual upload (fallback)
+
+```bash
+python -m pip install build twine
+python -m build
+twine upload dist/*
+```
+
+Use a PyPI API token only if trusted publishing is unavailable.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Hive Usage Guide
 
-**Version**: 0.5.0  
+**Version**: 0.6.1  
 **Target audience**: Engineers deploying Hive in production
 
 ---
@@ -35,14 +35,21 @@
 pip install hive-agent-memory
 ```
 
+### Full stack (CPU router + ML compressor)
+
+```bash
+pip install "hive-agent-memory[full]"
+```
+
 ### With all extras
 
 ```bash
-pip install hive-agent-memory[dev,monitor,observability]
+pip install "hive-agent-memory[dev,monitor,observability]"
 ```
 
 | Extra | What it adds |
 |-------|-------------|
+| `full` | busybee-cpu + honey-comb (from PyPI) |
 | `dev` | pytest, ruff, mypy |
 | `monitor` | pynvml (GPU monitoring) |
 | `observability` | Prometheus, OpenTelemetry |

--- a/hive-cpp/Cargo.toml
+++ b/hive-cpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-cpp"
-version = "0.5.0"
+version = "0.6.1"
 edition = "2021"
 description = "Native Rust backend for Hive"
 

--- a/hive-cpp/pyproject.toml
+++ b/hive-cpp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "hive-cpp"
-version = "0.5.0"
+version = "0.6.1"
 description = "Native Rust backend for Hive - 100x speedup over Python"
 requires-python = ">=3.8"
 classifiers = [

--- a/hive-cpp/python/hive_cpp/__init__.py
+++ b/hive-cpp/python/hive_cpp/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "rust_memory_retrieve",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.6.1"

--- a/hive/__init__.py
+++ b/hive/__init__.py
@@ -25,7 +25,7 @@ See :mod:`hive.stack` for the orchestrator.
 
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __all__ = ["HiveStack", "__version__"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hive-agent-memory"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hive: unified agent memory & context compression stack for 2026 NVIDIA + edge"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -38,41 +38,47 @@ classifiers = [
 #   rust_brain   : Timestamped graph memory (bundled in this repo at hive/rust_brain/)
 #   rule_fast    : In-repo rule-based compressor fallback (no honey-comb needed)
 #
-# For local development we install siblings via `pip install -e ../busyBee-cpu ../honey-comb`.
+# For local development install siblings via `pip install -e ../busyBee-cpu ../honey-comb`.
+# From PyPI use `pip install "hive-agent-memory[full]"` once siblings are published.
 dependencies = [
-    "joblib>=1.3",
-    "pydantic>=2.0",
-    "cryptography>=41.0",
-    "PyJWT>=2.8",
-    "numpy>=1.24",
-    "scikit-learn>=1.3",
-    # Component deps are pulled in via the local editable installs above.
-    # When installing from PyPI/Git releases they are pulled transitively.
+    "joblib>=1.4",
+    "pydantic>=2.10",
+    "cryptography>=43.0",
+    "PyJWT>=2.10",
+    "numpy>=1.26",
+    "scikit-learn>=1.4",
 ]
 
 [project.optional-dependencies]
+# Full stack: trained CPU router + ML compressor (siblings on PyPI)
+full = [
+    "busybee-cpu>=0.6.0,<0.7.0",
+    "honey-comb>=0.3.0,<0.4.0",
+]
 # GPU / inference (used by examples + integration, not required for the core stack)
 gpu = [
-    "torch>=2.1",
-    "transformers>=4.40",
+    "torch>=2.5",
+    "transformers>=4.46",
 ]
-vllm = ["vllm>=0.5"]
+vllm = ["vllm>=0.6"]
 # Hardware monitoring. pynvml works on NVIDIA + nvidia-ml-py on Jetson.
-monitor = ["pynvml>=2.0"]
+monitor = ["pynvml>=12.0"]
 # Native Rust backend for performance-critical workloads (optional)
-performance = ["hive-cpp>=0.1.0"]
+performance = ["hive-cpp>=0.6.0,<0.7.0"]
 # Real-time observability: Prometheus, OpenTelemetry, JSONL export
 observability = [
-    "prometheus-client>=0.20",
-    "opentelemetry-api>=1.40",
-    "opentelemetry-sdk>=1.40",
+    "prometheus-client>=0.21",
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
 ]
 dev = [
-    "pytest>=8.0",
+    "pytest>=8.3",
     "pytest-asyncio>=0.24",
-    "pytest-cov>=4.1",
-    "ruff>=0.5",
-    "mypy>=1.8",
+    "pytest-cov>=5.0",
+    "ruff>=0.8",
+    "mypy>=1.13",
+    "build>=1.2",
+    "twine>=5.1",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/hive_api_server.py
+++ b/scripts/hive_api_server.py
@@ -38,7 +38,9 @@ except Exception:  # pragma: no cover
 
 
 if _HAS_FASTAPI:
-    app = FastAPI(title="Hive Agent Memory", version="0.6.0")
+    from hive import __version__
+
+    app = FastAPI(title="Hive Agent Memory", version=__version__)
     stack = HiveStack(honey_comb=RuleFastHoneyComb())
 
     class RouteRequest(BaseModel):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ships **v0.6.1** with the unreleased rust_brain snapshot-integrity fix, enables PyPI distribution, and refreshes dependency pins.

### v0.6.1 release
- Moves the SHA-256 snapshot verification work from `[Unreleased]` into `CHANGELOG.md`
- Bumps version across `pyproject.toml`, `hive.__version__`, Helm chart, and `hive-cpp`
- FastAPI server now reads version from `hive.__version__`

### PyPI publishing (Phase 3)
- Adds `publish-pypi` job to `.github/workflows/release.yml` using `pypa/gh-action-pypi-publish` with GitHub OIDC
- Adds `[full]` optional extra: `busybee-cpu` + `honey-comb`
- New `docs/PYPI.md` with one-time trusted-publishing setup
- README / CONTRIBUTING / USAGE updated so `pip install hive-agent-memory` is the default path

### Dependency refresh
- Core: `joblib>=1.4`, `pydantic>=2.10`, `cryptography>=43.0`, `PyJWT>=2.10`, `numpy>=1.26`, `scikit-learn>=1.4`
- Extras: refreshed GPU, observability, dev, and `hive-cpp` pins

## Post-merge steps (required to publish)

1. **Configure PyPI trusted publishing** — see [`docs/PYPI.md`](docs/PYPI.md)
   - Create PyPI project `hive-agent-memory`
   - Add pending publisher for workflow `Release`, environment `pypi`
   - Create GitHub environment `pypi`

2. **Tag the release** (triggers build + PyPI upload + GitHub Release):
   ```bash
   git checkout main && git pull
   git tag v0.6.1
   git push origin v0.6.1
   ```

3. **Publish sibling packages** (for `[full]` extra to work):
   - `busybee-cpu` v0.6.0 from [busyBee-cpu](https://github.com/DJLougen/busyBee-cpu)
   - `honey-comb` v0.3.0 from [honey-comb](https://github.com/DJLougen/honey-comb)

## Test plan

- [x] `pytest` — 189 passed, 6 skipped
- [x] `ruff check hive/ tests/` — clean
- [x] `python -m build` — `hive_agent_memory-0.6.1` wheel + sdist built successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14b4-da57-7c17-bbc3-713a6717f110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14b4-da57-7c17-bbc3-713a6717f110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

